### PR TITLE
Fix Github Action for CMake tests.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,15 +21,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y build-essentials cmake libgtest-dev libabsl-dev libjsoncpp-dev
+        apt-get update -y
+        DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake libgtest-dev libabsl-dev libjsoncpp-dev
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ./build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ./build --config ${{env.BUILD_TYPE}}
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
+      working-directory: ./build
       run: ctest -C ${{env.BUILD_TYPE}}


### PR DESCRIPTION
- Don't use sudo in the container (we're already root).
- Use correct build-essential package.
- Make build directory relative (the absolute reference in the
  working-directory does not seem to work).
- Configure headless apt-get out of an abundance of caution.